### PR TITLE
Make the WS thing run

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor" # Select this runner for espflash v3.x.x
+runner = "espflash flash --monitor"
 rustflags = [ "--cfg",  "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [unstable]
@@ -11,8 +11,4 @@ build-std = ["std", "panic_abort"]
 
 [env]
 MCU="esp32c3"
-# Note: this variable is not used by the pio builder (`cargo build --features pio`)
-ESP_IDF_VERSION = "v5.2.2"
-
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"
+ESP_IDF_VERSION = "v5.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mawoka <git@mawoka.eu>"]
 edition = "2021"
 resolver = "2"
-rust-version = "1.77"
+rust-version = "1.84"
 
 [[bin]]
 name = "td-free-rs"
@@ -21,28 +21,16 @@ strip = true
 debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
-[features]
-# ota = ["dep:esp-ota"]
-default = ["std", "esp-idf-svc/native"]
-#critical-section-impl = ["critical-section/restore-state-none"]
-
-pio = ["esp-idf-svc/pio"]
-std = ["alloc", "esp-idf-svc/binstart", "esp-idf-svc/std"]
-alloc = ["esp-idf-svc/alloc"]
-nightly = ["esp-idf-svc/nightly"]
-experimental = ["esp-idf-svc/experimental"]
-
 [dependencies]
-log = { version = "0.4", default-features = false }
-esp-idf-svc = { version = "0.51", default-features = false, features= ["experimental", "embassy-time-driver"] }
+log = "0.4"
+esp-idf-svc = { version = "0.51", features= ["experimental", "embassy-time-driver", "critical-section"] }
 embedded-hal = "1"
 heapless = "0.8"
-edge-http = {version = "0.5", features = ["embedded-svc"]}
-embedded-io-async = { version = "0.6", default-features = false }
-edge-nal-std = {version = "0.5"}
+edge-http = "0.5.1"
+embedded-io-async = "0.6"
+edge-nal-std = { version = "0.5", features = ["async-io-mini"] }
 edge-nal = "0.5"
 edge-ws = "0.4"
-futures-lite = "2.6"
 
 
 anyhow = "1"
@@ -50,13 +38,12 @@ url = "2.5"
 
 
 veml7700 = "0.2.0"
-embassy-time = { version = "0.4.0", features = ["log", "std", "generic-queue-8"] }
+embassy-time = { version = "0.4", features = ["log", "generic-queue-8"] }
 
 [build-dependencies]
-embuild = {version = "0.33.0", features = ["espidf"]}
+embuild = {version = "0.33", features = ["espidf"]}
 vergen-gix = { version = "1", features = ["build", "rustc"] }
 anyhow = "1"
-cc = "=1.1.20"
 
 # [package.metadata.espflash]
 # partition_table = "partitions.csv"

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,13 +1,2 @@
-# Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=99000
-#CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=15000
-#CONFIG_HTTPD_WS_SUPPORT=y
-#CONFIG_LWIP_LOCAL_HOSTNAME=tdfree
-
-# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
-# This allows to use 1 ms granularity for thread sleeps (10 ms by default).
-#CONFIG_FREERTOS_HZ=1000
-
-# Workaround for https://github.com/espressif/esp-idf/issues/7631
-#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=15000
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096


### PR DESCRIPTION
- To fix the linking errors, you have to remove feature "std" from `embassy-time`. It doesn't do what you think it does

- To make `edge-nal-std` happy you need to initialize the EventFd ESP-IDF VFS subsystem

- To reduce the stack size a bit you need to be extra careful what you put on stack, especially in `async` functions, where this size is doubled, and even quadrupled with extra `async` functions' nesting

- I've also cleaned up your `Cargo.toml` a bit and a few others like `sdkconfig.defaults` as they contained stuff which is not really used or done in a more cumbersome way than necessary (this is coming from the old `esp-idf-template`)

NOTE: Take it or leave it, but I'm deleting my fork of `td-free` in a few days, so hurry up! :)